### PR TITLE
Feature/93 cache network bookmarks strategy

### DIFF
--- a/foodbook_app/lib/bloc/bookmark_view_bloc/bookmark_view_state.dart
+++ b/foodbook_app/lib/bloc/bookmark_view_bloc/bookmark_view_state.dart
@@ -13,6 +13,13 @@ class BookmarkedRestaurantsLoaded extends BookmarkViewState {
 class BookmarksLoadInProgress extends BookmarkViewState {} 
 
 class BookmarksLoadFailure extends BookmarkViewState {
-  final String error;
-  BookmarksLoadFailure(this.error);
+  final List<Restaurant> successfullyLoaded;
+  final List<String> failedToLoadNames;
+  final String errorMessage;
+
+  BookmarksLoadFailure({
+    required this.successfullyLoaded,
+    required this.failedToLoadNames,
+    required this.errorMessage,
+  });
 }

--- a/foodbook_app/lib/presentation/views/restaurant_view/bookmarks_view.dart
+++ b/foodbook_app/lib/presentation/views/restaurant_view/bookmarks_view.dart
@@ -56,7 +56,7 @@ class _BookmarksViewState extends State<BookmarksView> {
                 return const Center(child: CircularProgressIndicator());
               } else if (state is BookmarkedRestaurantsLoaded) {
                 if (state.bookmarkedRestaurants.isEmpty) {
-                  return const Center(child: Text('No bookmarks found in cache.'));
+                  return const Center(child: Text('No bookmarked restaurants.'));
                 }
                 return ListView.builder(
                   itemCount: state.bookmarkedRestaurants.length,
@@ -76,7 +76,38 @@ class _BookmarksViewState extends State<BookmarksView> {
                   },
                 );
               } else if (state is BookmarksLoadFailure) {
-                return Center(child: Text('Failed to load restaurants'));
+                //The message changes if there is 1 or more than 1 restaurant that couldn't be loaded
+                final failureMessage = state.failedToLoadNames.length == 1
+                    ? "The bookmarked restaurant: ${state.failedToLoadNames.first} is not in cache and couldn't be accessed through network. Try again with an internet connection."
+                    : "The bookmarked restaurants: ${state.failedToLoadNames.join(', ')} are not in cache and couldn't be accessed through network. Try again with an internet connection.";
+                return Column(
+                  children: [
+                    if (state.successfullyLoaded.isNotEmpty)
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: state.successfullyLoaded.length,
+                          itemBuilder: (context, index) {
+                            final restaurant = state.successfullyLoaded[index];
+                            return GestureDetector(
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => SpotDetail(restaurant: restaurant),
+                                  ),
+                                );
+                              },
+                              child: RestaurantCard(restaurant: restaurant),
+                            );
+                          },
+                        ),
+                      ),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Text(failureMessage, textAlign: TextAlign.center),
+                    ),
+                  ],
+                );
               }
               // If state is BookmarkViewInitial or any other unhandled state, show a loading indicator
               return const Center(child: CircularProgressIndicator());

--- a/foodbook_app/lib/presentation/widgets/menu/navigation_bar.dart
+++ b/foodbook_app/lib/presentation/widgets/menu/navigation_bar.dart
@@ -65,7 +65,10 @@ class CustomNavigationBar extends StatelessWidget {
         } else if (index == 2) {
           Navigator.of(context).pushReplacement(MaterialPageRoute(
               builder: (context) => BlocProvider<BookmarkViewBloc>(
-                  create: (context) => BookmarkViewBloc(BookmarkManager()), 
+                  create: (context) => BookmarkViewBloc(
+                    bookmarkManager: BookmarkManager(),
+                    restaurantRepository: RestaurantRepository(),
+                  ),
                   child: BookmarksView(),
               ),
           ));


### PR DESCRIPTION
Finished cache then network strategy for bookmarks. In this case what is done is that taking into account the bookmarks feature implemented before there was added a method that searches for restaurants in the bookmarked list in local storage but not cache. The messages for different scenarios where also implemented, from the case there are no bookmarks, when there are some and when one couldn't be accessed neither by cache or network:

![imagen](https://github.com/ISIS3510-202410-Team23/FlutterApp/assets/78111596/758b4925-1dce-4d20-b2c1-e9227c5c1173)

![imagen](https://github.com/ISIS3510-202410-Team23/FlutterApp/assets/78111596/52c13492-40e0-40fe-97fa-6a66d01a69a6)

![imagen](https://github.com/ISIS3510-202410-Team23/FlutterApp/assets/78111596/87544929-43ec-4b50-8f22-af36c8122bdf)
