### PR TITLE
Fix/128 spot detail fetch logic change

### DIFF
--- a/foodbook_app/lib/bloc/spot_detail_bloc/spot_detail_bloc.dart
+++ b/foodbook_app/lib/bloc/spot_detail_bloc/spot_detail_bloc.dart
@@ -1,0 +1,32 @@
+// spot_detail_bloc.dart
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_event.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_state.dart';
+import 'package:foodbook_app/data/models/restaurant.dart';
+import 'package:foodbook_app/data/repositories/restaurant_repository.dart';
+
+
+class SpotDetailBloc extends Bloc<SpotDetailEvent, SpotDetailState> {
+  final RestaurantRepository restaurantRepository;
+
+  SpotDetailBloc(this.restaurantRepository) : super(SpotDetailInitial()) {
+    on<FetchRestaurantDetail>(_onFetchRestaurantDetail);
+  }
+
+  Future<void> _onFetchRestaurantDetail(
+    FetchRestaurantDetail event,
+    Emitter<SpotDetailState> emit,
+  ) async {
+    emit(SpotDetailLoadInProgress());
+    try {
+      final Restaurant? restaurant = await restaurantRepository.fetchRestaurantById(event.restaurantId);
+      if (restaurant != null) {
+        emit(SpotDetailLoadSuccess(restaurant));
+      } else {
+        emit(SpotDetailLoadFailure('Restaurant not found.'));
+      }
+    } catch (e) {
+      emit(SpotDetailLoadFailure(e.toString()));
+    }
+  }
+}

--- a/foodbook_app/lib/bloc/spot_detail_bloc/spot_detail_event.dart
+++ b/foodbook_app/lib/bloc/spot_detail_bloc/spot_detail_event.dart
@@ -1,0 +1,6 @@
+abstract class SpotDetailEvent {}
+
+class FetchRestaurantDetail extends SpotDetailEvent {
+  final String restaurantId;
+  FetchRestaurantDetail(this.restaurantId);
+}

--- a/foodbook_app/lib/bloc/spot_detail_bloc/spot_detail_state.dart
+++ b/foodbook_app/lib/bloc/spot_detail_bloc/spot_detail_state.dart
@@ -1,0 +1,17 @@
+import 'package:foodbook_app/data/models/restaurant.dart';
+
+abstract class SpotDetailState {}
+
+class SpotDetailInitial extends SpotDetailState {}
+
+class SpotDetailLoadInProgress extends SpotDetailState {}
+
+class SpotDetailLoadSuccess extends SpotDetailState {
+  final Restaurant restaurant;
+  SpotDetailLoadSuccess(this.restaurant);
+}
+
+class SpotDetailLoadFailure extends SpotDetailState {
+  final String message;
+  SpotDetailLoadFailure(this.message);
+}

--- a/foodbook_app/lib/main.dart
+++ b/foodbook_app/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:foodbook_app/bloc/search_bloc/search_bloc.dart';
 import 'package:foodbook_app/bloc/user_bloc/user_bloc.dart';
 import 'package:foodbook_app/data/data_access_objects/shared_preferences_dao.dart';
 import 'package:foodbook_app/data/repositories/auth_repository.dart';
+import 'package:foodbook_app/data/repositories/restaurant_repository.dart';
 import 'package:foodbook_app/data/repositories/shared_preferences_repository.dart';
 import 'package:foodbook_app/notifications/background_review_reminder.dart';
 import 'package:foodbook_app/notifications/background_task.dart';
@@ -71,41 +72,43 @@ Future<void> requestLocationPermission() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-   @override
-   Widget build(BuildContext context) {
-     return RepositoryProvider(
-       create: (context) => AuthRepository(),
-       child: MultiBlocProvider(
-         providers: [
-           BlocProvider<AuthBloc>(
-             create: (context) => AuthBloc(
-               authRepository: RepositoryProvider.of<AuthRepository>(context),
-             ),
-           ),
-           BlocProvider<UserBloc>(
-             create: (context) => UserBloc(),
-           ),
-         ],
-         child: MaterialApp(
-           title: 'FoodBook',
-           theme: ThemeData(
-             primarySwatch: Colors.blue,
-           ),
-           home: const SignInView(),
-         ),
-       ),
-     );
+  @override
+  Widget build(BuildContext context) {
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider<AuthRepository>(
+          create: (context) => AuthRepository(),
+        ),
+        RepositoryProvider<RestaurantRepository>(
+          create: (context) => RestaurantRepository(),
+        ),
+        // Add other repositories here if needed
+      ],
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthBloc>(
+            create: (context) => AuthBloc(
+              authRepository: RepositoryProvider.of<AuthRepository>(context),
+            ),
+          ),
+          BlocProvider<UserBloc>(
+            create: (context) => UserBloc()
+            ),
+          // Add other BlocProviders here if needed
+        ],
+        child: MaterialApp(
+          title: 'FoodBook',
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+          ),
+          home: const SignInView(),
+          // Define the routing and other MaterialApp properties here
+        ),
+      ),
+    );
   }
-
-//   Widget build(BuildContext context) {
-//   return MaterialApp(
-//     title: 'FoodBook App',
-//     home: BlocProvider(
-//       create: (context) => SearchBloc(),
-//       child: SearchPage2(),
-//     ),
-//   );
-// }
-
 }
+
+
+
 

--- a/foodbook_app/lib/presentation/views/restaurant_view/bookmarks_view.dart
+++ b/foodbook_app/lib/presentation/views/restaurant_view/bookmarks_view.dart
@@ -4,6 +4,8 @@ import 'package:foodbook_app/bloc/bookmark_bloc/bookmark_bloc.dart';
 import 'package:foodbook_app/bloc/bookmark_view_bloc/bookmark_view_bloc.dart';
 import 'package:foodbook_app/bloc/bookmark_view_bloc/bookmark_view_event.dart';
 import 'package:foodbook_app/bloc/bookmark_view_bloc/bookmark_view_state.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_event.dart';
 import 'package:foodbook_app/data/repositories/bookmark_manager.dart';
 import 'package:foodbook_app/presentation/views/spot_infomation_view/spot_detail_view.dart';
 import 'package:foodbook_app/presentation/widgets/menu/navigation_bar.dart';
@@ -64,13 +66,13 @@ class _BookmarksViewState extends State<BookmarksView> {
                     final restaurant = state.bookmarkedRestaurants[index];
                     return GestureDetector(
                       onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => SpotDetail(restaurant: restaurant),
-                          ),
-                        );
-                      },
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => SpotDetail(restaurantId: state.bookmarkedRestaurants[index].id),
+                                ),
+                              );
+                            },
                       child: RestaurantCard(restaurant: restaurant),
                     );
                   },
@@ -89,11 +91,16 @@ class _BookmarksViewState extends State<BookmarksView> {
                           itemBuilder: (context, index) {
                             final restaurant = state.successfullyLoaded[index];
                             return GestureDetector(
-                              onTap: () {
+                              onTap: () async {
+                                final restaurantId = restaurant.id;
+
+                                // Use a RestaurantBloc event to fetch the restaurant details
+                                context.read<SpotDetailBloc>().add(FetchRestaurantDetail(restaurantId));
+
                                 Navigator.push(
                                   context,
                                   MaterialPageRoute(
-                                    builder: (context) => SpotDetail(restaurant: restaurant),
+                                    builder: (context) => SpotDetail(restaurantId: restaurantId),
                                   ),
                                 );
                               },

--- a/foodbook_app/lib/presentation/views/restaurant_view/browse_view.dart
+++ b/foodbook_app/lib/presentation/views/restaurant_view/browse_view.dart
@@ -5,8 +5,11 @@ import 'package:foodbook_app/bloc/bookmark_bloc/bookmark_event.dart';
 import 'package:foodbook_app/bloc/browse_bloc/browse_bloc.dart';
 import 'package:foodbook_app/bloc/browse_bloc/browse_state.dart';
 import 'package:foodbook_app/bloc/search_bloc/search_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_event.dart';
 import 'package:foodbook_app/bloc/user_bloc/user_bloc.dart';
 import 'package:foodbook_app/bloc/user_bloc/user_event.dart';
+import 'package:foodbook_app/data/repositories/restaurant_repository.dart';
 import 'package:foodbook_app/presentation/views/profile_view/profile_view.dart';
 import 'package:foodbook_app/presentation/views/spot_infomation_view/spot_detail_view.dart';
 import 'package:foodbook_app/presentation/views/test_views/search_test.dart';
@@ -85,11 +88,10 @@ class BrowseView extends StatelessWidget {
                         itemBuilder: (context, index) {
                           return GestureDetector(
                             onTap: () {
-                              // Navigate to another view when the restaurant card is clicked
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(
-                                  builder: (context) => SpotDetail(restaurant: state.restaurants[index]),
+                                  builder: (context) => SpotDetail(restaurantId: state.restaurants[index].id),
                                 ),
                               );
                             },

--- a/foodbook_app/lib/presentation/views/restaurant_view/for_you_view.dart
+++ b/foodbook_app/lib/presentation/views/restaurant_view/for_you_view.dart
@@ -4,6 +4,8 @@ import 'package:foodbook_app/bloc/bookmark_bloc/bookmark_bloc.dart';
 import 'package:foodbook_app/bloc/browse_bloc/browse_bloc.dart';
 import 'package:foodbook_app/bloc/browse_bloc/browse_event.dart';
 import 'package:foodbook_app/bloc/browse_bloc/browse_state.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_event.dart';
 import 'package:foodbook_app/bloc/user_bloc/user_bloc.dart';
 import 'package:foodbook_app/bloc/user_bloc/user_event.dart';
 import 'package:foodbook_app/bloc/user_bloc/user_state.dart';
@@ -82,7 +84,7 @@ class _ForYouViewState extends State<ForYouView> {
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(
-                                  builder: (context) => SpotDetail(restaurant: state.recommendedRestaurants[index]),
+                                  builder: (context) => SpotDetail(restaurantId: state.recommendedRestaurants[index].id),
                                 ),
                               );
                             },

--- a/foodbook_app/lib/presentation/views/spot_infomation_view/spot_detail_view.dart
+++ b/foodbook_app/lib/presentation/views/spot_infomation_view/spot_detail_view.dart
@@ -3,9 +3,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:foodbook_app/bloc/review_bloc/food_category_bloc/food_category_bloc.dart';
 import 'package:foodbook_app/bloc/review_bloc/stars_bloc/stars_bloc.dart';
 import 'package:foodbook_app/bloc/reviewdraft_bloc/reviewdraft_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_bloc.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_event.dart';
+import 'package:foodbook_app/bloc/spot_detail_bloc/spot_detail_state.dart';
 import 'package:foodbook_app/data/data_sources/database_provider.dart';
 import 'package:foodbook_app/data/models/restaurant.dart';
 import 'package:foodbook_app/data/repositories/category_repository.dart';
+import 'package:foodbook_app/data/repositories/restaurant_repository.dart';
 import 'package:foodbook_app/data/repositories/reviewdraft_repository.dart';
 import 'package:foodbook_app/presentation/views/review_view/categories_stars_view.dart';
 import 'package:foodbook_app/presentation/views/review_view/restaurant_reviews_view.dart';
@@ -13,9 +17,37 @@ import 'package:foodbook_app/presentation/views/spot_infomation_view/spot_map.da
 
 
 class SpotDetail extends StatelessWidget {
+  final String restaurantId;
+
+  const SpotDetail({Key? key, required this.restaurantId}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<SpotDetailBloc>(
+      create: (context) => SpotDetailBloc(
+        RepositoryProvider.of<RestaurantRepository>(context),
+      )..add(FetchRestaurantDetail(restaurantId)),
+      child: BlocBuilder<SpotDetailBloc, SpotDetailState>(
+        builder: (context, state) {
+          if (state is SpotDetailLoadInProgress) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is SpotDetailLoadSuccess) {
+            return SpotDetailView(restaurant: state.restaurant);
+          } else if (state is SpotDetailLoadFailure) {
+            return SpotDetailViewFailure(message: 'Failed to load restaurant.');
+          } else {
+            return const Center(child: Text('Unknown error.'));
+          }
+        },
+      ),
+    );
+  }
+}
+
+class SpotDetailView extends StatelessWidget {
   final Restaurant restaurant;
 
-  const SpotDetail({super.key, required this.restaurant});
+  const SpotDetailView({Key? key, required this.restaurant}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -209,6 +241,30 @@ class SpotDetail extends StatelessWidget {
             ],
           ),
         ],
+      ),
+    );
+  }
+}
+
+// If the SpotDetailLoadFailure state is emitted, the SpotDetailView widget will show the back button in the app bar and a failure message in the center of the screen.
+class SpotDetailViewFailure extends StatelessWidget {
+  final String message;
+
+  const SpotDetailViewFailure({Key? key, required this.message}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: Center(
+        child: Text(message),
       ),
     );
   }

--- a/foodbook_app/lib/presentation/views/test_views/search_test.dart
+++ b/foodbook_app/lib/presentation/views/test_views/search_test.dart
@@ -133,7 +133,7 @@ Widget buildResults(BuildContext context) {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => SpotDetail(restaurant: state.restaurants[index]),
+                      builder: (context) => SpotDetail(restaurantId: state.restaurants[index].id),
                     ),
                   );
                 },


### PR DESCRIPTION
Implemented spot detail logic changes so that we load the complete restaurant information when accesing the spot detail. This way we can access it from the cached cards without the need of saving all the information in cache, saving space. 